### PR TITLE
Timeout the file remediation jobs if no output is produced

### DIFF
--- a/app/jobs/remediation_job.rb
+++ b/app/jobs/remediation_job.rb
@@ -1,21 +1,26 @@
 # frozen_string_literal: true
 
 class RemediationJob < ApplicationJob
-  def perform(job_uuid)
+  OUTPUT_POLLING_INTERVAL = 10 # This value was picked somewhat arbitrarily. We may want to adjust.
+
+  # The default 1-hour timeout is also arbitrary and should probably be adjusted.
+  def perform(job_uuid, output_polling_timeout = 3600)
     job = Job.find_by!(uuid: job_uuid)
     tempfile = Down.download(job.source_url)
     object_key = "#{SecureRandom.hex(8)}_#{tempfile.original_filename}"
     s3 = S3Handler.new(object_key)
     s3.upload_to_input(tempfile.path)
 
-    until output_url = s3.presigned_url_for_output
-      sleep 10 # This value was picked somewhat arbitrarily. We may want to adjust.
+    timer = 0
 
-      # We'll probably want this to time out eventually and record a failure if the
-      # output file isn't found after some reasonably long period of time, but I don't
-      # think that we know how long we should wait yet. Also, I don't yet know if there
-      # is any other way to detect a file remediation failure apart from the absence of
-      # an output file. If there is, then we'll want to check for that.
+    until output_url = s3.presigned_url_for_output
+      sleep OUTPUT_POLLING_INTERVAL
+      timer += OUTPUT_POLLING_INTERVAL
+
+      if timer > output_polling_timeout
+        record_failure_and_notify(job, 'Timed out waiting for output file')
+        return true
+      end
     end
 
     job.update(
@@ -28,21 +33,23 @@ class RemediationJob < ApplicationJob
     RemediationStatusNotificationJob.perform_later(job_uuid)
   rescue Down::Error => e
     # We may want to retry the download depending on the more specific nature of the failure.
-    record_failure(job, "Failed to download file from source URL:  #{e.message}")
+    record_failure_and_notify(job, "Failed to download file from source URL:  #{e.message}")
   rescue S3Handler::Error => e
     # We may want to retry the upload depending on the more specific nature of the failure.
-    record_failure(job, "Failed to upload file to remediation input location:  #{e.message}")
+    record_failure_and_notify(job, "Failed to upload file to remediation input location:  #{e.message}")
   ensure
     tempfile&.close!
   end
 
   private
 
-    def record_failure(job, message)
+    def record_failure_and_notify(job, message)
       job.update(
         status: 'failed',
         finished_at: Time.zone.now,
         processing_error_message: message
       )
+
+      RemediationStatusNotificationJob.perform_later(job.uuid)
     end
 end

--- a/spec/jobs/remediation_job_spec.rb
+++ b/spec/jobs/remediation_job_spec.rb
@@ -19,13 +19,15 @@ RSpec.describe RemediationJob do
   let(:s3) {
     instance_spy(
       S3Handler,
-      presigned_url_for_output: 'https://example.com/presigned-file-url'
+      presigned_url_for_output: output_url
     )
   }
+  let(:output_url) { 'https://example.com/presigned-file-url' }
 
   before do
     allow(Down).to receive(:download).with('https://test.com/file.pdf').and_return file
     allow(S3Handler).to receive(:new).with(/[a-f0-9]{16}_file\.pdf/).and_return s3
+    allow(RemediationStatusNotificationJob).to receive(:perform_later)
   end
 
   describe '#perform' do
@@ -43,9 +45,38 @@ RSpec.describe RemediationJob do
       expect(reloaded_job.output_object_key).to match /[a-f0-9]{16}_file\.pdf/
     end
 
+    it 'queues up a notification about the status of the job' do
+      described_class.perform_now(job.uuid)
+      expect(RemediationStatusNotificationJob).to have_received(:perform_later).with(job.uuid)
+    end
+
     it 'closes the temporarily downloaded file' do
       described_class.perform_now(job.uuid)
       expect(file).to have_received(:close!)
+    end
+
+    context 'when an output file is not produced before the timeout is exceeded' do
+      let(:output_url) { nil }
+
+      it 'updates the status and metadata of the given job record' do
+        described_class.perform_now(job.uuid, 1)
+        reloaded_job = job.reload
+        expect(reloaded_job.status).to eq 'failed'
+        expect(reloaded_job.output_url).to be_nil
+        expect(reloaded_job.finished_at).to be_within(1.minute).of(Time.zone.now)
+        expect(reloaded_job.output_object_key).to be_nil
+        expect(reloaded_job.processing_error_message).to eq 'Timed out waiting for output file'
+      end
+
+      it 'queues up a notification about the status of the job' do
+        described_class.perform_now(job.uuid, 1)
+        expect(RemediationStatusNotificationJob).to have_received(:perform_later).with(job.uuid)
+      end
+
+      it 'closes the temporarily downloaded file' do
+        described_class.perform_now(job.uuid, 1)
+        expect(file).to have_received(:close!)
+      end
     end
 
     context 'when an error occurs while downloading the source file' do
@@ -61,6 +92,11 @@ RSpec.describe RemediationJob do
         expect(reloaded_job.finished_at).to be_within(1.minute).of(Time.zone.now)
         expect(reloaded_job.output_object_key).to be_nil
         expect(reloaded_job.processing_error_message).to eq 'Failed to download file from source URL:  download error'
+      end
+
+      it 'queues up a notification about the status of the job' do
+        described_class.perform_now(job.uuid)
+        expect(RemediationStatusNotificationJob).to have_received(:perform_later).with(job.uuid)
       end
     end
 
@@ -79,6 +115,11 @@ RSpec.describe RemediationJob do
         expect(reloaded_job.processing_error_message).to eq(
           'Failed to upload file to remediation input location:  upload error'
         )
+      end
+
+      it 'queues up a notification about the status of the job' do
+        described_class.perform_now(job.uuid)
+        expect(RemediationStatusNotificationJob).to have_received(:perform_later).with(job.uuid)
       end
 
       it 'closes the temporarily downloaded file' do


### PR DESCRIPTION
Also, notify clients of failures as well as success.