### PR TITLE
Bind mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
     volumes:
     - bundle-data:/app/vendor/bundle
     - node-data:/app/node_modules
+    - type: bind
+      source: ./
+      target: /app
     ports:
       - "3000:3000"
   db:


### PR DESCRIPTION
Adding a bind mount so that developers can immediately see changes to rails application, instead of being required to rebuild the container.