### PR TITLE
Implement the webhook for remediation job status notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ gem 'aws-sdk-s3', '~> 1.0'
 # Temporary file downloads over HTTP
 gem 'down'
 
+# HTTP client
+gem 'faraday'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mswin mswin64 mingw x64_mingw], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,12 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faraday (2.13.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
@@ -170,6 +176,8 @@ GEM
     minitest (5.25.5)
     msgpack (1.8.0)
     mysql2 (0.5.6)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.9)
       date
       net-protocol
@@ -358,6 +366,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
     useragent (0.16.11)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -383,6 +392,7 @@ DEPENDENCIES
   down
   error_highlight (>= 0.4.0)
   factory_bot_rails
+  faraday
   jbuilder
   mysql2
   niftany

--- a/app/jobs/remediation_status_notification_job.rb
+++ b/app/jobs/remediation_status_notification_job.rb
@@ -1,8 +1,31 @@
 # frozen_string_literal: true
 
 class RemediationStatusNotificationJob < ApplicationJob
-  def perform(_job_uuid)
-    # temporary stub until we implement the webhook
-    nil
+  def perform(job_uuid)
+    job = Job.find_by!(uuid: job_uuid)
+
+    body = if job.completed?
+             {
+               event_type: 'job.succeeded',
+               job: job.as_json(only: [:uuid, :status, :output_url])
+             }
+           else
+             {
+               event_type: 'job.failed',
+               job: job.as_json(only: [:uuid, :status, :processing_error_message])
+             }
+           end
+
+    conn = Faraday.new(
+      url: job.webhook_endpoint,
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-API-Key' => job.webhook_key
+      }
+    )
+
+    conn.post do |req|
+      req.body = body.to_json
+    end
   end
 end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -5,6 +5,9 @@ class APIUser < ApplicationRecord
 
   before_create :set_keys
 
+  validates :webhook_endpoint, presence: true
+  validates :webhook_endpoint, format: { with: URI::RFC2396_PARSER.make_regexp('https') }
+
   private
 
     def set_keys

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -9,4 +9,10 @@ class Job < ApplicationRecord
   validates :source_url, format: { with: URI::RFC2396_PARSER.make_regexp }
 
   belongs_to :owner, polymorphic: true
+
+  delegate :webhook_endpoint, :webhook_key, to: :owner, prefix: false
+
+  def completed?
+    status == 'completed'
+  end
 end

--- a/spec/factories/api_users.rb
+++ b/spec/factories/api_users.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :api_user
+  factory :api_user do
+    webhook_endpoint { 'https://test.com/endpoint' }
+  end
 end

--- a/spec/jobs/remediation_status_notification_job_spec.rb
+++ b/spec/jobs/remediation_status_notification_job_spec.rb
@@ -3,9 +3,55 @@
 require 'rails_helper'
 
 RSpec.describe RemediationStatusNotificationJob do
+  let(:user) { create(:api_user, webhook_endpoint: 'https://test.com/webhook') }
+  let!(:job) {
+    create(
+      :job,
+      status: status,
+      owner: user,
+      output_url: 'https://example.com/output',
+      processing_error_message: 'failed to process'
+    )
+  }
+  let(:status) { 'completed' }
+  let(:http_client) { instance_double Faraday::Connection }
+  let(:request) { instance_spy Faraday::Request }
+
+  before do
+    allow(Faraday).to receive(:new).with(
+      url: 'https://test.com/webhook',
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-API-Key' => job.webhook_key
+      }
+    ).and_return(http_client)
+
+    allow(http_client).to receive(:post).and_yield request
+  end
+
   describe '#perform' do
-    it 'returns nil' do
-      expect(described_class.perform_now('abc123')).to be_nil
+    context 'when the given job is completed' do
+      it "POSTs a success notification to the job's webhook endpoint" do
+        described_class.perform_now(job.uuid)
+
+        expect(request).to have_received(:body=).with(
+          "{\"event_type\":\"job.succeeded\",\"job\":{\"uuid\":\"#{job.uuid}\"," \
+          '"status":"completed","output_url":"https://example.com/output"}}'
+        )
+      end
+    end
+
+    context 'when the given job has failed' do
+      let(:status) { 'failed' }
+
+      it "POSTs a failure notification to the job's webhook endpoint" do
+        described_class.perform_now(job.uuid)
+
+        expect(request).to have_received(:body=).with(
+          "{\"event_type\":\"job.failed\",\"job\":{\"uuid\":\"#{job.uuid}\"," \
+          '"status":"failed","processing_error_message":"failed to process"}}'
+        )
+      end
     end
   end
 end

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe APIUser do
     it { is_expected.to have_many(:jobs).dependent(:restrict_with_exception) }
   end
 
+  describe 'validations' do
+    subject(:user) { described_class.new }
+
+    it { is_expected.to validate_presence_of(:webhook_endpoint) }
+
+    it 'validates the format of webhook_endpoint' do
+      expect(user).not_to allow_value('').for(:webhook_endpoint)
+      expect(user).not_to allow_value('invalid').for(:webhook_endpoint)
+      expect(user).not_to allow_value('test.com/invalid').for(:webhook_endpoint)
+      expect(user).not_to allow_value('http://test.com/webhook').for(:webhook_endpoint)
+
+      expect(user).to allow_value('https://test.com/webhook').for(:webhook_endpoint)
+    end
+  end
+
   describe 'creating a new API user' do
     let(:api_user) { build(:api_user, api_key: nil, webhook_key: nil) }
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -49,4 +49,27 @@ RSpec.describe Job do
       expect(described_class.statuses).to eq ['processing', 'completed', 'failed']
     end
   end
+
+  it { is_expected.to delegate_method(:webhook_endpoint).to(:owner) }
+  it { is_expected.to delegate_method(:webhook_key).to(:owner) }
+
+  describe '#completed?' do
+    let(:job) { described_class.new }
+
+    context 'when the job status is "completed"' do
+      before { job.status = 'completed' }
+
+      it 'returns true' do
+        expect(job.completed?).to be true
+      end
+    end
+
+    context 'when the job status is not "completed"' do
+      before { job.status = 'failed' }
+
+      it 'returns false' do
+        expect(job.completed?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #8 

Here's how this could work, I suppose. I think that this provides enough information to the webhook receiver that it can ensure idempotence if the same webhook request is sent more than once. We can change up how these requests look if we want or need to. Our own applications will probably be the only users of this webhook, at least for a while. So we can tailor this however we want to suit our own needs.

Since this is running as a separate background job, do we actually need error handling and retry logic within the job? Or do we just let it throw errors and allow sidekiq to handle retries?