### PR TITLE
Docker compose cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,13 @@ COPY --chown=app . /app
 
 FROM base AS dev-worker
 
-CMD ["bundle", "exec", "sidekiq"]
+RUN chmod +x entrypoints/dev-worker.sh
+ENTRYPOINT ["entrypoints/dev-worker.sh"]
 
 FROM base AS dev-mock-remediation-tool
 
-CMD ["bin/mock_remediation_tool"]
+RUN chmod +x entrypoints/dev-mock-remediation-tool.sh
+ENTRYPOINT ["entrypoints/dev-mock-remediation-tool.sh"]
 
 FROM base AS dev
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       context: .
       target: dev
     volumes:
-    - bundle-data:/app/vendor/bundle
-    - node-data:/app/node_modules
+      - bundle-data:/app/vendor/bundle
+      - node-data:/app/node_modules
     ports:
       - "3000:3000"
     healthcheck:

--- a/entrypoints/dev-mock-remediation-tool.sh
+++ b/entrypoints/dev-mock-remediation-tool.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+echo "[dev-mock-remediation-tool] Starting..."
+
+# Ensure gems are available
+bundle check || bundle install
+
+# Run tool
+exec bundle exec bin/mock_remediation_tool

--- a/entrypoints/dev-worker.sh
+++ b/entrypoints/dev-worker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+echo "[dev-worker] Starting..."
+
+# Ensure gems are available
+bundle check || bundle install
+
+# Start Sidekiq
+exec bundle exec sidekiq


### PR DESCRIPTION
Adds entrypoints for the dev-worker and dev-mock-remediation-tool services.  This will run bundle if 'bundle check' fails.  Then they run their respective services