### PR TITLE
87 - redirects non-api requests to an authorized page

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ErrorsController < ApplicationController
+  def unauthorized; end
+end

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -1,0 +1,3 @@
+<main class='container-fluid'>
+  <p class='alert'><%= I18n.t('authentication.no_auth') %></p>
+</main>

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 Rails.configuration.middleware.use RailsWarden::Manager do |manager|
-  manager.failure_app = ->(_env) {
-    [401, { 'Content-Type' => 'application/json' }, [{ message: 'Not authorized', code: 401 }.to_json]]
-  }
+  manager.failure_app = CustomFailureApp
 
   manager.default_strategies :http_header_auth
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,5 @@ en:
     heading: PDF Accessibility Remediation
     description: ''
     copyright_statement: 'Copyright © 2025 The Pennsylvania State University'
+  authentication:
+    no_auth: You are not authorized to use this resource.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,6 @@ Rails.application.routes.draw do
       post '/jobs', to: 'jobs#create'
     end
   end
+
+  get '/unauthorized', to: 'errors#unauthorized'
 end

--- a/lib/custom_failure_app.rb
+++ b/lib/custom_failure_app.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CustomFailureApp
+  def self.call(env)
+    original_path = env['ORIGINAL_FULLPATH'] || env['REQUEST_PATH'] || '/'
+    if original_path.start_with?('/api')
+      [401, { 'Content-Type' => 'application/json' },
+       [{ message: 'Not authorized', code: 401 }.to_json]]
+    else
+      [302, { 'Location' => '/unauthorized', 'Content-Type' => 'text/html' },
+       ['Redirecting to unauthorized page']]
+    end
+  end
+end

--- a/spec/requests/gui_auth_spec.rb
+++ b/spec/requests/gui_auth_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe 'Warden Http Header Authentication' do
   end
 
   context 'when user is not allowlisted' do
-    it 'returns 401 status and redirects to 401 page' do
+    it 'returns 302 status and redirects to unauthorized page' do
       get '/jobs/new', headers: { 'HTTP_X_AUTH_REQUEST_EMAIL' => 'test2@psu.edu' }
       expect(request.path).to eq '/unauthenticated'
-      expect(response).to have_http_status :unauthorized
-      expect(response.body).to include 'Not authorized'
+      expect(response).to have_http_status :redirect
+      expect(response.body).to include 'Redirecting to unauthorized page'
     end
   end
 end

--- a/spec/requests/sidekiq_access_spec.rb
+++ b/spec/requests/sidekiq_access_spec.rb
@@ -12,12 +12,16 @@ RSpec.describe 'Sidekiq Access Constraint' do
   it 'redirects access for unauthorized user' do
     get '/sidekiq', headers: { 'HTTP_X_AUTH_REQUEST_EMAIL' => 'unauthorized@example.com' }
 
-    expect(response).to have_http_status(:unauthorized)
+    expect(request.path).to eq '/unauthenticated'
+    expect(response).to have_http_status :redirect
+    expect(response.body).to include 'Redirecting to unauthorized page'
   end
 
   it 'redirects access when header is missing' do
     get '/sidekiq'
 
-    expect(response).to have_http_status(:unauthorized)
+    expect(request.path).to eq '/unauthenticated'
+    expect(response).to have_http_status :redirect
+    expect(response.body).to include 'Redirecting to unauthorized page'
   end
 end


### PR DESCRIPTION
closes #87 

Uses a Custom Failure App to check whether the calls are in the API namespace and then return the appropriate response.