### PR TITLE
add temp re-creation so that it has the correct permissions 🤞

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN RAILS_ENV=production \
   bundle exec rails assets:precompile && \
   rm -rf /app/.cache/ && \
   rm -rf /app/node_modules/.cache/ && \
-  rm -rf /app/tmp/
+  rm -rf /app/tmp/ && \
+  mkdir /app/tmp && chown -R app:app /app/tmp
 
 CMD ["bin/startup"]


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process to ensure that the `tmp` directory exists and has the correct ownership after asset precompilation.

* Dockerfile: After removing `/app/tmp`, the build now recreates the directory and sets its ownership to the `app` user to prevent potential permission issues at runtime.