### PR TITLE
Change bugsnag environment variable

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -2,6 +2,6 @@
 
 Bugsnag.configure do |config|
   config.app_version = ENV.fetch('APP_VERSION', nil)
-  config.release_stage = ENV.fetch('APP_ENV', 'development')
+  config.release_stage = ENV.fetch('BUGSNAG_RELEASE_STAGE', 'development')
   config.api_key = ENV.fetch('BUGSNAG_API_KEY', nil)
 end


### PR DESCRIPTION
`APP_ENV` conflicted with SideKiq, which uses it like `RAILS_ENV`. Changed to `BUGSNAG_RELEASE_STAGE`.