### PR TITLE
Remove test expectation that is no longer accurate

### DIFF
--- a/spec/features/jobs/new_spec.rb
+++ b/spec/features/jobs/new_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature 'New job', :js do
     attach_file('./spec/fixtures/files/testing.pdf')
     click_button 'Upload'
     sleep 1
-    expect(Rails.root.glob('tmp/uploads/*_testing.pdf').count).to eq(file_count + 1)
     expect(page).to have_current_path(job_path(Job.last))
   end
 end


### PR DESCRIPTION
@ajkiessl 
Am I correct in thinking that the expectation that I removed here is always going to fail now that the background jobs are being run in the test environment? I'm assuming that when the job runs, it cleans up the temporary file upload that we were expecting to see before?

If that's correct, then do you think that we should add anything else to improve the test coverage?