### PR TITLE
Run the build-and-push CI step in branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,7 @@ workflows:
           name: deploy-image
           requires:
             - build-and-push
+            - test-application
       - release-image:
           context:
             - org-global
@@ -181,6 +182,7 @@ workflows:
           name: release-image
           requires:
             - build-and-push
+            - test-application
       - test-application:
           context:
             - org-global


### PR DESCRIPTION
For a bit more context: we want the production build done in the branches so we know it won't fail once we merge to `main`.  It looks like we do this for other projects, but idk if "pushing" for every branch will overload harbor.

Also, I have the build-and-push running parallel with test-application