### PR TITLE
Prepend input prefix to object key when generating presigned url for input

### DIFF
--- a/app/controllers/pdf_jobs_controller.rb
+++ b/app/controllers/pdf_jobs_controller.rb
@@ -17,12 +17,11 @@ class PdfJobsController < GUIAuthController
   end
 
   def sign
-    filename     = params[:filename].presence || "upload/#{SecureRandom.uuid}"
-    content_type = params[:content_type].presence || 'application/pdf'
+    filename = params[:filename]
 
     object_key = "#{SecureRandom.hex(8)}_#{filename}"
     s3_handler = S3Handler.new(object_key)
-    render json: s3_handler.presigned_url_for_input(object_key, content_type)
+    render json: s3_handler.presigned_url_for_input
   end
 
   def complete

--- a/app/services/s3_handler.rb
+++ b/app/services/s3_handler.rb
@@ -44,20 +44,21 @@ class S3Handler
     raise Error.new(e)
   end
 
-  def presigned_url_for_input(key, content_type)
+  def presigned_url_for_input
     signer = Aws::S3::Presigner.new(client: @s3_client)
+    key = "#{INPUT_PREFIX}#{@object_key}"
 
     url = signer.presigned_url(
       :put_object,
       bucket: @bucket.name,
       key: key,
-      content_type: content_type,
+      content_type: 'application/pdf',
       expires_in: 900 # 15 minutes
     )
     {
       url: url,
       headers: {
-        'Content-Type' => content_type
+        'Content-Type' => 'application/pdf'
       },
       object_key: @object_key
     }

--- a/bin/mock_remediation_tool
+++ b/bin/mock_remediation_tool
@@ -24,7 +24,7 @@ begin
 
   logger.info "Mock PDF remediation tool running..."
   loop do
-    bucket.objects.select { |o| o.key !~/result\/COMPLIANT/ }.each do |o|
+    bucket.objects(prefix: S3Handler::INPUT_PREFIX).each do |o|
       filename = o.key.gsub(S3Handler::INPUT_PREFIX, "")
       result_key = "#{S3Handler::OUTPUT_PREFIX}#{filename}"
 

--- a/spec/services/s3_handler_spec.rb
+++ b/spec/services/s3_handler_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe S3Handler, type: :service do
       end
 
       it 'returns json with the url, headers, and object_key' do
-        expect(handler.presigned_url_for_input(object_key, content_type)).to eq(
+        expect(handler.presigned_url_for_input).to eq(
           {
             url: url,
             headers: { 'Content-Type' => content_type.to_s },
@@ -88,11 +88,11 @@ RSpec.describe S3Handler, type: :service do
       end
 
       it "calls the AWS Signer's #presigned_url method" do
-        handler.presigned_url_for_input(object_key, content_type)
+        handler.presigned_url_for_input
         expect(signer).to have_received(:presigned_url).with(
           :put_object,
           bucket: ENV.fetch('S3_BUCKET_NAME'),
-          key: object_key,
+          key: "#{S3Handler::INPUT_PREFIX}#{object_key}",
           content_type: content_type,
           expires_in: 900
         )


### PR DESCRIPTION
I noticed files weren't being processed in QA.  I realized the files were not getting prepended with "pdf/", so they were not being picked up by the remediation application.  I made a few changes to fix this:

>>Removed arguments for S3Handler#presigned_url_for_input since the object key is retrievable from an instance method and the content type should always be a pdf.  Removed some extra things from the controller.  Fixed mock remediation tool to only remediate files in the pdf/ directory in the bucket.