### PR TITLE
"Default" is new default

### DIFF
--- a/app/jobs/image_alt_text_job.rb
+++ b/app/jobs/image_alt_text_job.rb
@@ -13,7 +13,7 @@ class ImageAltTextJob < ApplicationJob
     alt_text = client.process_image(
       tmp_path,
       prompt: Rails.root.join('prompt.txt').read,
-      model_id: ENV.fetch('LLM_MODEL', 'nil')
+      model_id: ENV.fetch('LLM_MODEL', 'default')
     )
     job.update(
       status: 'completed',

--- a/spec/jobs/image_alt_text_job_spec.rb
+++ b/spec/jobs/image_alt_text_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ImageAltTextJob do
 
       it 'calls the Alt Text gem' do
         expect(alt_text_gem).to have_received(:process_image).with(
-          /.+\.jpg/, prompt: File.read('prompt.txt'), model_id: ENV.fetch('LLM_MODEL', nil)
+          /.+\.jpg/, prompt: File.read('prompt.txt'), model_id: ENV.fetch('LLM_MODEL', 'default')
         )
       end
 


### PR DESCRIPTION
In QA, the alt-text service isn't working because an ENV variable hasn't been set for LLM_MODEL. We should add one, but we should also make the default value "default", because the AltText gem accepts "default" as an argument and will run with the most commonly used LLM.