### PR TITLE
removed building and testing from the release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,6 +216,9 @@ workflows:
             branches:
               only:
                 - main
+          requires:
+            - build-and-push
+            - test-application
       - deploy-application:
           name: deploy-preview
           context:


### PR DESCRIPTION
There's no need to build and test a release:

 - a release does nothing but tag an already built, tested and pushed image in harbor
 - then inserts the tag into the application's production manifest in the config repo