### PR TITLE
pushing image to harbor requires success of building and testing jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,20 +58,6 @@ executors:
 
 jobs:
 
-  push-image:
-    environment:
-      REGISTRY_HOST: harbor.k8s.libraries.psu.edu
-      REGISTRY_REPO: "library/$CIRCLE_PROJECT_REPONAME"
-    executor:
-      name: ci-utils
-      image_tag: << pipeline.parameters.CI_UTILS_IMAGE_TAG >>
-    steps:
-      - compute-docker-tag
-      - docker/push:
-          image: $REGISTRY_REPO
-          registry: $REGISTRY_HOST
-          tag: $TAG
-
   build-image:
     environment:
       REGISTRY_HOST: harbor.k8s.libraries.psu.edu
@@ -102,6 +88,20 @@ jobs:
           tag: $TAG
           extra_build_args: "--target production"
           use-buildkit: true
+
+  push-image:
+    environment:
+      REGISTRY_HOST: harbor.k8s.libraries.psu.edu
+      REGISTRY_REPO: "library/$CIRCLE_PROJECT_REPONAME"
+    executor:
+      name: ci-utils
+      image_tag: << pipeline.parameters.CI_UTILS_IMAGE_TAG >>
+    steps:
+      - compute-docker-tag
+      - docker/push:
+          image: $REGISTRY_REPO
+          registry: $REGISTRY_HOST
+          tag: $TAG
 
   delete-deployment:
     parameters:


### PR DESCRIPTION

This divides the build-and-push job into two separate jobs:

 - build-image - builds the image parallel with test-application, decreases time spent waiting for CI
 - push-image - pushes image to harbor, only after build-image and test-application successfully complete 

