### PR TITLE
remove branch filters from test-application workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,8 +329,4 @@ workflows:
           name: test-application
           context:
             - org-global
-          filters:
-            branches:
-              only:
-                - main
-                - /preview\/.*/
+


### PR DESCRIPTION
- Eliminated specific branch filters for the test-application workflow to allow broader execution of full test suite (will later create a fast-test version and limit full test suite to PRs)