### PR TITLE
Adds navigation link in RailsAdmin side nav to Sidekiq dashboard

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -10,4 +10,9 @@ RailsAdmin.config do |config|
   config.current_user_method do
     warden.user
   end
+
+  config.navigation_static_label = 'Tools'
+  config.navigation_static_links = {
+    'Sidekiq' => '/sidekiq'
+  }
 end

--- a/spec/features/admin/rails_admin_navigation_spec.rb
+++ b/spec/features/admin/rails_admin_navigation_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Rails Admin navigation' do
+  let!(:admin_user) { create(:gui_user, email: 'test1@psu.edu') }
+
+  before do
+    login_as(admin_user)
+  end
+
+  it 'navigates to Sidekiq from the Rails Admin screen' do
+    visit '/admin'
+
+    expect(page).to have_link('Sidekiq', href: '/sidekiq')
+
+    click_link 'Sidekiq'
+
+    expect(page).to have_current_path(%r{\A/sidekiq\z})
+  end
+end


### PR DESCRIPTION
closes #245 

Screenshot of nav link:


<img width="289" height="372" alt="Screenshot 2026-03-09 at 3 29 27 PM" src="https://github.com/user-attachments/assets/331b8eed-9760-44b7-b65f-cabebe7e298e" />
