### PR TITLE
Backoff/throttle S3 checks in poller more

### DIFF
--- a/app/services/check_s3_for_final_files_service.rb
+++ b/app/services/check_s3_for_final_files_service.rb
@@ -6,7 +6,7 @@ class CheckS3ForFinalFilesService
   include AppJobModule
 
   CHECK_S3_PER_JOB_INTERVAL = 1 # Throttle S3 checks while iterating processing jobs
-  CHECK_S3_IDLE_INTERVAL = 10 # Back off when there are no processing jobs
+  CHECK_S3_IDLE_INTERVAL = 10 # Back off to avoid excessive S3 checking
   CHECK_S3_FAILED_LIMIT = 3600 # 1 hour limit before marking job as failed
 
   def call(run_once: false)


### PR DESCRIPTION
Backoff/throttle S3 checks a bit more so we aren't churning like crazy when we don't need to.

Iirc every request sent to S3 costs $$$.  It's probably a very small amount of money, but we want to be careful about how many requests we send.