### PR TITLE
Include in progress PdfJobs when scoping for PdfJobs list

### DIFF
--- a/app/models/pdf_job.rb
+++ b/app/models/pdf_job.rb
@@ -7,7 +7,7 @@ class PdfJob < Job
   delegate :webhook_endpoint, :webhook_key, to: :owner, prefix: false
 
   def self.not_expired
-    where('output_url_expires_at > ?', Time.zone.now)
+    where('output_url_expires_at IS NULL OR output_url_expires_at > ?', Time.zone.now)
   end
 
   def output_url_expired?

--- a/spec/models/pdf_job_spec.rb
+++ b/spec/models/pdf_job_spec.rb
@@ -69,12 +69,11 @@ RSpec.describe PdfJob do
   end
 
   describe '#self.not_expired' do
-    let(:pending_job) { build(:pdf_job) }
+    let(:pending_job) { create(:pdf_job) }
 
     before do
       job.update!(output_url_expires_at: 1.hour.from_now)
       gui_job.update!(output_url_expires_at: 1.hour.ago)
-      pending_job.save!
     end
 
     it 'returns jobs with a valid download link or no expiration timestamp' do

--- a/spec/models/pdf_job_spec.rb
+++ b/spec/models/pdf_job_spec.rb
@@ -69,13 +69,16 @@ RSpec.describe PdfJob do
   end
 
   describe '#self.not_expired' do
+    let(:pending_job) { build(:pdf_job) }
+
     before do
       job.update!(output_url_expires_at: 1.hour.from_now)
       gui_job.update!(output_url_expires_at: 1.hour.ago)
+      pending_job.save!
     end
 
-    it 'returns a list of jobs with a valid download link' do
-      expect(described_class.not_expired).to eq([job])
+    it 'returns jobs with a valid download link or no expiration timestamp' do
+      expect(described_class.not_expired).to contain_exactly(job, pending_job)
     end
   end
 end


### PR DESCRIPTION
Add filter to include PdfJobs with no `output_url_expires_at` timestamp in the `not_expired` scope.  Tests for this.