### PR TITLE
Configure Uppy to not use multipart

### DIFF
--- a/app/javascript/controllers/pdf_uppy_controller.js
+++ b/app/javascript/controllers/pdf_uppy_controller.js
@@ -34,6 +34,7 @@ export default class extends Controller {
         doneButtonHandler: null,
       })
       .use(AwsS3, {
+        shouldUseMultipart: false,
         getUploadParameters: async (file) => {
           const pageCount = await this.getPageCount(file)
           const resp = await fetch('/pdf_jobs/sign', {


### PR DESCRIPTION
For slightly larger files, Uppy was switching to multipart uploading on it's own.  We don't have multipart uploads implemented, so it was failing.  Uppy can still handle fairly large files without multipart, but it needs to be explicitly told not to use multipart.  This configuration tells Uppy not to ever use multipart.