### PR TITLE
Add error handling to Bugsnag configuration for specific actions

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -4,4 +4,10 @@ Bugsnag.configure do |config|
   config.app_version = ENV.fetch('APP_VERSION', nil)
   config.release_stage = ENV.fetch('BUGSNAG_RELEASE_STAGE', 'development')
   config.api_key = ENV.fetch('BUGSNAG_API_KEY', nil)
+
+  config.add_on_error(proc do |event|
+    action = event.request&.dig(:railsAction)
+
+    event.ignore! if action&.start_with?('ok_computer')
+  end)
 end


### PR DESCRIPTION
This pull request adds logic to the Bugsnag initializer to prevent error events from health check actions (those starting with `ok_computer`) from being reported. This helps reduce noise in error monitoring by ignoring expected requests.

* Bugsnag error reporting:
  * [`config/initializers/bugsnag.rb`](diffhunk://#diff-644eb09c7f9824a3e542e6bb7782df49af4634c3ed8df3b4e588519ebaa644d1R7-R12): Added a `config.add_on_error` block that ignores events where the Rails action starts with `ok_computer`, preventing health check errors from being reported.