### PR TITLE
Test/remove docker24 pin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: docker24
           docker_layer_caching: true
       - run:
           name: Install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,10 @@ jobs:
           name: Build and run containers
           command: docker-compose -f docker-compose.yml build && docker-compose -f docker-compose.yml up --force-recreate -d
       - run:
+          name: Capture web container logs on failure
+          command: docker-compose -f docker-compose.yml logs web
+          when: on_fail
+      - run:
           name: Wait for mysql to be ready
           command: docker-compose exec web bash ./wait_for_db.sh
       - run:

--- a/bin/startup
+++ b/bin/startup
@@ -8,7 +8,11 @@ fi
 if [ "${RAILS_ENV:-development}" != "production" ]; then
   bundle check || bundle
   echo "Initalizing the database"
-  sleep 10 && bundle exec rails db:create db:migrate
+  until bash -c "echo > /dev/tcp/db/3306" 2>/dev/null; do
+    echo "Waiting for db..."
+    sleep 2
+  done
+  bundle exec rails db:create db:migrate
 fi
 
 echo "starting rails"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ x-web_env: &web_env
   ADMIN_USERS_ROLE: ${ADMIN_USERS_ROLE}
 services:
   web:
-    user: "${UID}:${GID}"
+    user: "${UID:-3000}:${GID:-3000}"
     depends_on:
       db:
         condition: service_healthy
@@ -47,7 +47,7 @@ services:
       retries: 5
       start_period: 30s
   s3_poller:
-    user: "${UID}:${GID}"
+    user: "${UID:-3000}:${GID:-3000}"
     depends_on:
       db:
         condition: service_healthy
@@ -65,7 +65,7 @@ services:
     volumes:
       - bundle-data:/app/vendor/bundle
   worker:
-    user: "${UID}:${GID}"
+    user: "${UID:-3000}:${GID:-3000}"
     depends_on:
       web:
         condition: service_healthy
@@ -78,7 +78,7 @@ services:
       - worker-bundle-data:/app/vendor/bundle
       - uploads-tmp-data:/app/tmp/uploads
   mock_remediation_tool:
-    user: "${UID}:${GID}"
+    user: "${UID:-3000}:${GID:-3000}"
     depends_on:
       web:
         condition: service_healthy


### PR DESCRIPTION
This pull request makes improvements to the Docker and CI/CD configuration to enhance reliability and developer experience. The main changes include setting default user and group IDs for Docker containers and improving CI diagnostics by capturing logs on failure.

**Docker Compose improvements:**

* Set default values for the `UID` and `GID` environment variables in the `docker-compose.yml` file for the `web`, `s3_poller`, `worker`, and `mock_remediation_tool` services. This ensures containers run as user and group `3000` if `UID` or `GID` are not explicitly provided, improving compatibility across different environments. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L22-R22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L50-R50) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L68-R68) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L81-R81)

**CI/CD pipeline improvements:**

* Added a step in `.circleci/config.yml` to capture and display the `web` container logs automatically when a job fails, making it easier to debug CI failures.
* Removed the explicit `version: docker24` parameter from the `setup_remote_docker` step, potentially allowing CircleCI to use its default Docker version.